### PR TITLE
Return latest Entity Configuration (sort by creation date)

### DIFF
--- a/modules/openid-federation-persistence/src/commonMain/sqldelight/com/sphereon/oid/fed/persistence/models/EntityConfigurationStatement.sq
+++ b/modules/openid-federation-persistence/src/commonMain/sqldelight/com/sphereon/oid/fed/persistence/models/EntityConfigurationStatement.sq
@@ -10,5 +10,5 @@ findLatestByAccountId:
 SELECT *
 FROM EntityConfigurationStatement
 WHERE account_id = ?
-ORDER BY id DESC
+ORDER BY created_at DESC
 LIMIT 1;


### PR DESCRIPTION
The old Entity Configuration Statements for the root are persisted in the database. The SQL query tries to pick the latest by ordering them by `id`. This used to work when the identifiers were sequential numbers, but has been broken since the identifiers were changed to be UUIDs.

Ordering the persisted statements by creation date should return the latest statement.